### PR TITLE
Upgrade the webextension-toolbox package name

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -7,6 +7,6 @@
     "build": "webextension-toolbox build"
   },
   "devDependencies": {
-    "webextension-toolbox": "latest"
+    "@webextension-toolbox/webextension-toolbox": "latest"
   }
 }


### PR DESCRIPTION
`webextension-toolbox` is deprecated and will not receive updates.